### PR TITLE
Remove .gitconfig from source control

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[user]
-	name = Codema-dev
-	email = codema-dev@codema.ie
-[core]
-	editor = vim

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # But not these files...
 !.gitignore
-!.gitconfig
 !.zshrc
 !.zsh_aliases
 !.p10k.zsh


### PR DESCRIPTION
Require manual update instead...

Git requires user id before commit which is then stored in .gitconfig; so doesn't make sense to keep this under source control...