### PR TITLE
Remove codema-dev as user!

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,2 @@
-[user]
-	name = Codema-dev
-	email = codema-dev@codema.ie
 [core]
 	editor = vim


### PR DESCRIPTION
Git prompts user to add email and username prior to committing anyway!  We should each use own personal email and not codema-dev@codema.ie