### PR TITLE
Remove gitconfig from source control

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[user]
-	name = Codema-dev
-	email = codema-dev@codema.ie
-[core]
-	editor = vim

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,5 @@
+[user]
+	name = Codema-dev
+	email = codema-dev@codema.ie
+[core]
+	editor = vim

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # But not these files...
 !.gitignore
+!.gitconfig
 !.zshrc
 !.zsh_aliases
 !.p10k.zsh

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # But not these files...
 !.gitignore
-!.gitconfig
 !.zshrc
 !.zsh_aliases
 !.p10k.zsh


### PR DESCRIPTION
Git queries user details by default on first commit,
can't have a shared .gitconfig accross users