### PR TITLE
Add conda init to zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -131,3 +131,19 @@ path+=('$HOME/.local/bin')
 path+='/usr/local/bin' # to access brew
 export path
 
+
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$('/opt/conda/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
+        . "/opt/conda/etc/profile.d/conda.sh"
+    else
+        export PATH="/opt/conda/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+


### PR DESCRIPTION
So can skip initialisation step when setting up
new docker zsh containers