### PR TITLE
Add prefect user config env var for drem

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -147,3 +147,4 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 
+export PREFECT__USER_CONFIG_PATH="/drem/prefect-config.toml"


### PR DESCRIPTION
So drem users can add their own drem environmental
variables via a toml file and prefect will automatically
see it