### PR TITLE
Remove conda init

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -131,20 +131,4 @@ path+=('$HOME/.local/bin')
 path+='/usr/local/bin' # to access brew
 export path
 
-
-# >>> conda initialize >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/opt/conda/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
-        . "/opt/conda/etc/profile.d/conda.sh"
-    else
-        export PATH="/opt/conda/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda initialize <<<
-
 export PREFECT__USER_CONFIG_PATH="/drem/prefect-config.toml"


### PR DESCRIPTION
conda init activates conda and so poetry shell
uses the conda virtualenv instead of its local
virtualenv.  Require users to conda init zsh followed
by conda activate...